### PR TITLE
Added Albert, weather plugin and removed double software-common

### DIFF
--- a/plugins/albert.plugin/install.sh
+++ b/plugins/albert.plugin/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+add-apt-repository ppa:nilarimogard/webupd8
+apt-get -y update
+apt-get -y install albert

--- a/plugins/albert.plugin/metadata.json
+++ b/plugins/albert.plugin/metadata.json
@@ -1,0 +1,20 @@
+{
+	"icon": "albert",
+  "description": "A fast, lightweight quick launcher for linux",
+	"label": "Albert",
+	"license": "Free",
+	"category": "Utilities",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root apt purge -y albert"
+		},
+		"status": {
+			"command": "dpkg -s albert"
+		}
+	}
+}

--- a/plugins/spotify.plugin/install.sh
+++ b/plugins/spotify.plugin/install.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-apt install -y software-properties-common
 add-apt-repository -y "deb http://repository.spotify.com stable non-free"
 apt-key -y adv --keyserver keyserver.ubuntu.com --recv-keys 94558F59
 apt -y update

--- a/plugins/spotify.plugin/install.sh
+++ b/plugins/spotify.plugin/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+apt install -y software-properties-common
 add-apt-repository -y "deb http://repository.spotify.com stable non-free"
 apt-key -y adv --keyserver keyserver.ubuntu.com --recv-keys 94558F59
 apt -y update

--- a/plugins/weather-indicator.plugin/install.sh
+++ b/plugins/weather-indicator.plugin/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+apt-get -y update
+apt-get -y install my-weather-indicator

--- a/plugins/weather-indicator.plugin/metadata.json
+++ b/plugins/weather-indicator.plugin/metadata.json
@@ -1,0 +1,20 @@
+{
+	"icon": "my-weather-indicator",
+  "description": "A simple indicator for the weather",
+	"label": "my-weather-indicator",
+	"license": "Free",
+	"category": "Utilities",
+	"scripts": {
+		"exec": {
+			"label": "Install",
+			"command": "run-as-root -s install.sh"
+		},
+		"undo": {
+			"label": "Remove",
+			"command": "run-as-root apt purge -y my-weather-indicator"
+		},
+		"status": {
+			"command": "dpkg -s my-weather-indicator"
+		}
+	}
+}


### PR DESCRIPTION
Added Albert and my-weather-indicator
also noticed the software-common line is twice in there.

1st on the enable-ppa.plugin folder
and then on the spotify.. was probably intended but didn't make sense to me, will spin up a quick VM to test it out.